### PR TITLE
docs: proof read xcall document

### DIFF
--- a/docs/adr/xcall.md
+++ b/docs/adr/xcall.md
@@ -1,28 +1,44 @@
 # XCall
 
-
 ## Introduction
+
 xCall is a standard interface to make calls between different blockchain networks.
 
 ## Protocol Overview
+
 ![](https://hackmd.io/_uploads/SkBUxFhBh.png)
 
-
 ## Prerequisites
+
 ### Network Addresses
-XCall uses network address to refer to different addresses across many networks. A "network address" consists of a network and an account section. A network address is represented as a string with "networkId" and "account" separated by /.
-A networkId is a unique id of a network and there can't be two networks with the same id connected to the same xCall network.
+
+XCall uses network address to refer to different addresses across many networks.
+A `network address` consists of a network and an account section.
+A network address is represented as a string with "networkId" and "account" separated by /.
+A networkId is a unique id of a network, and there can't be two networks with the same id connected to the same xCall
+network.
 
 ### Connections
-XCall is designed to utilize a wide range of bridging protocols that facilitate data transfer, known as connections. These connections can be selected by users and dApps, ensuring a permissionless protocol. However, this places a responsibility on the dApps to verify that they exclusively accept messages from trusted protocols. Users can also opt to use the default connections set up by the xCall admin and in this case does not need to manage connections at all.
+
+XCall is designed to utilize a wide range of bridging protocols that facilitate data transfer, known as connections.
+These connections can be selected by users and dApps, ensuring a permissionless protocol.
+However, this places a responsibility on the dApps to verify that they exclusively accept messages from trusted
+protocols.
+Users can also opt to use the default connections set up by the xCall admin, and in this case does not need to manage
+connections at all.
 
 ## Protocol Specification
+
 ### Sending Messages
-Sending messages via xCall is simply done by calling sendCallMessage on the xCall contract. `_to` address is a networkAddress used by xCall to figure out the destination chain.
-The user can also  specify which connections to use, if not specified the default connections will be used. This also allows dapps to have their messages secured by multiple protocols.
+
+Sending messages via xCall is simply done by calling sendCallMessage on the xCall contract.
+`_to` address is a networkAddress used by xCall to figure out the destination chain.
+The user can also specify which connections to use, if not specified, the default connections will be used.
+This also allows dapps to have their messages secured by multiple protocols.
 
 The default connections are specified by and admin and can be changed at any time.
-```javascript
+
+```
 /**
  * Sends a call message to the contract on the destination chain.
  *
@@ -40,16 +56,20 @@ payable external sendCallMessage(String _to,
                                 @Optional String[] sources
                                 @Optional String[] destinations) return Integer;
 ```
+
 ### Events
+
 #### CallMessage
+
 CallMessage event is emitted when a new message is received by xCall and is ready to be executed.
 
- `_from` The network address of the caller on the source chain
- `_to` A string representation of the callee address
- `_sn` The serial number of the request from the source
- `_reqId` The request id of the destination chain used in execute call
- `_data` The calldata
-```javascript
+- `_from` The network address of the caller on the source chain
+- `_to` A string representation of the callee address
+- `_sn` The serial number of the request from the source
+- `_reqId` The request id of the destination chain used in execute call
+- `_data` The calldata
+
+```
 CallMessage {
     String _from,
     String _to,
@@ -58,55 +78,73 @@ CallMessage {
     byte[] data
 }
 ```
+
 #### CallExecuted
+
 CallExecuted event is emitted when a message is executed
- `_reqId` The message id
- `_code` The execution result code (1: Success, 0: failure)
- `_msg` Error message
-```javascript
+
+- `_reqId` The message id
+- `_code` The execution result code (1: Success, 0: failure)
+- `_msg` Error message
+
+```
 CallExecuted{
     Integer _reqId,
     Integer _code,
     String _msg
 }
 ```
+
 #### ResponseMessage
-ResponseMessage is emitted for all two-way messages (i.e., _rollback is non-null), the xcall on the source chain receives a response message from the xcall on the destination chain and emits the following event regardless of its success or not.
- `_sn` The message id
- `_code` The execution result code (1: Success, 0: failure)
-```javascript
+
+ResponseMessage is emitted for all two-way messages (i.e., _rollback is non-null), the xcall on the source chain
+receives a response message from the xcall on the destination chain and emits the following event regardless of its
+success or not.
+
+- `_sn` The message id
+- `_code` The execution result code (1: Success, 0: failure)
+
+```
 ResponseMessage{
     Integer _sn,
     Integer _code
 }
 ```
+
 #### RollbackMessage
-RollbackMessage is emitted when an error occurred on the destination chain and the _rollback is non-null, xcall on the source chain emits the following event for notifying the user that an additional rollback operation is required.
- `_sn` The message id
-```javascript
+
+RollbackMessage is emitted when an error occurred on the destination chain and the _rollback is non-null, xcall on the
+source chain emits the following event for notifying the user that an additional rollback operation is required.
+
+- `_sn` The message id
+
+```
 RollbackMessage {
     Integer _sn
 }
 ```
 
-
 #### RollbackExecuted
+
 RollbackExecuted event is emitted when a rollback message is executed.
- `_sn` The message id
-```javascript
+
+- `_sn` The message id
+
+```
 RollbackExecuted{
-    Integer _sn,
+    Integer _sn
 }
 ```
 
-
 #### CallMessageSent
-CallMessageSent is emitted when for each message sent.
- ` _from` The network address of the caller
- `_to` The network address of the calle
- `_sn` The serial number of the request
 
-```javascript
+CallMessageSent is emitted for each sent message.
+
+- ` _from` The network address of the caller
+- `_to` The network address of the callee
+- `_sn` The serial number of the request
+
+```
 CallMessageSent{
     Address _from,
     String _to,
@@ -118,12 +156,15 @@ CallMessageSent{
 
 #### Execution
 
-The user on the destination chain recognizes the call request and invokes the following method on xcall with the given _reqId and _data.
-To minimize the gas cost, the calldata payload delivered from the source chain are exported to event, `_data` field, instead of storing it in the state db. In case of a two-way message rollback will be triggered in case of failure.
+The user on the destination chain recognizes the call request and invokes the following method on xcall with the
+given `_reqId` and `_data`.
+To minimize the gas cost, the calldata payload delivered from the source chain is exported to event, `_data` field,
+instead of storing it in the state db.
+In the case of a two-way message, rollback will be triggered in case of failure.
 The `_data` payload should be repopulated by the user (or client) when calling the following `executeCall` method.
 Then `xcall` compares it with the saved hash value to validate its integrity.
 
-```javascript
+```
 /**
  * Executes the requested call message.
  *
@@ -133,10 +174,12 @@ Then `xcall` compares it with the saved hash value to validate its integrity.
 external executeCall(BigInteger _reqId, byte[] _data);
 ```
 
-The user on the source chain recognizes the rollback situation and invokes the following method on xcall with the given _sn.
+The user on the source chain recognizes the rollback situation and invokes the following method on xcall with the
+given `_sn`.
 Note that the executeRollback can be called only when the original call request has responded with a failure.
 It should be reverted when there is no failure response with the call request.
-```javascript
+
+```
 /**
  * Rollbacks the caller state of the request '_sn'.
  *
@@ -147,8 +190,11 @@ external executeRollback(BigInteger _sn);
 
 #### Handling
 
-When the user calls executeCall or executeRollback method, the xcall invokes the following predefined method in the target DApp with the calldata associated in _reqId. If only using default protocols implementing only the two parameter version is preferred.
-```javascript
+When the user calls executeCall or executeRollback method, the xcall invokes the following predefined method in the
+target DApp with the calldata associated in _reqId.
+If only using default protocols, implementing only the two parameter versions of function call is preferred.
+
+```
 /**
  * Handles the call message received from the source chain.
  * Only called from the Call Message Service.
@@ -160,13 +206,17 @@ When the user calls executeCall or executeRollback method, the xcall invokes the
 external handleCallMessage(String _from, byte[] _data);
 external handleCallMessage(String _from, byte[] _data, @Optional String[] _protocols);
 ```
-In case of rollback the _from will be the network address of the xCall contract. A rollback can only be delivered by the same protocols used to send the message, so the _protocols will be the protocols used to send the message. So they can be assumed to be safe as long as all messages sent have been done using trusted protocols.
+
+In case of rollback, the `_from` will be the network address of the xCall contract.
+A rollback can only be delivered by the same protocols used to send the message,
+so the `_protocols` will be the protocols used to send the message.
+So they can be assumed to be safe as long as all messages sent have been done using trusted protocols.
 
 #### Success verification
+
 If rollback was specified and the call was successful, the success can be verified.
 
-
-```javascript
+```
 /**
  * checks if message '_sn' did succeed on target chain.
  *
@@ -177,10 +227,11 @@ If rollback was specified and the call was successful, the success can be verifi
 external readonly verifySuccess(BigInteger _sn) returns boolean;
 ```
 
-### Fee Managment
-Sending a message through xCall has 2 types of fees. One for using the protocol and one for each connections used.
+### Fee Management
 
-```javascript
+Sending a message through xCall has two types of fees. One for using the protocol and one for each connection used.
+
+```
 /**
  * Gets the fee for delivering a message to the _net.
  * If the sender is going to provide rollback data, the _rollback param should set as true.
@@ -197,7 +248,7 @@ external readonly getFee(String _net,
                           @Optional String[] sources) returns Integer;
 ```
 
-```javascript
+```
 /**
  * Gets the protocol fee for sending a xCall message
  *
@@ -206,46 +257,66 @@ external readonly getFee(String _net,
 external readonly getProtocolFee() Returns Integer;
 ```
 
-
 ### Security Considerations
 
-The security of xCall comes from the security of the underlying connections. It is up to the dapp to verify that protocols are checked to be valid during `handleCallMessage`.
+The security of xCall comes from the security of the underlying connections.
+It is up to the dapp to verify that protocols are checked to be valid during `handleCallMessage`.
 
 ## Implementation Guidelines
 
 ### Connections
-The provided code snippet demonstrates a specific behavior of a connection. It consists of two external functions: sendMessage(targetNetwork, svc, sn, msg) and getFee(network, response).
 
-The sendMessage function is responsible for sending a message to a specified targetNetwork. It accepts four parameters: targetNetwork, svc, sn, and msg.
+The provided code snippet demonstrates a specific behavior of a connection.
+It consists of two external functions: `sendMessage(targetNetwork, svc, sn, msg)` and `getFee(network, response)`.
 
-The behavior of sendMessage depends on the value of sn (sequence number). If sn is greater than 0, it indicates a new message that requires a response. In this case, both the sending fee and the response fee should be included. If sn is 0, it signifies a one-way message where no response is expected. If sn is less than 0, it implies that the message is a response to a previously received message. In this scenario, no fee is included in the sending message since it should have already been paid when the positive sn was sent.
+The `sendMessage` function is responsible for sending a message to a specified targetNetwork.
+It accepts four parameters: `targetNetwork`, `svc`, `sn`, and `msg`.
 
-After handling the sn value, the sendMessage function triggers the handleMessage function on the targetNetwork. It passes targetNetwork and msg as arguments to handleMessage on xCall.
+The behavior of sendMessage depends on the value of sn (sequence number).
 
-In case the message fails to be delivered for any reason, the connection triggers the handleError function. It passes the failed sn to the function. The responsibility of this function is to handle errors that occur during the message delivery process.
+- If `sn > 0`, it indicates a new message that requires a response.
+  In this case, both the sending fee and the response fee should be included.
+- If `sn == 0`, it signifies a one-way message where no response is expected.
+- If `sn < 0`, it implies that the message is a response to a previously received message.
+  In this scenario, no fee is included in the sending message since it should have already been paid when the positive
+  sn was sent.
 
-The second external function, getFee(network, response), calculates and returns the fee required to send a message to the specified network and back. It takes into account the optional response parameter when determining the fee.
+After handling the sn value, the sendMessage function triggers the `handleMessage` function on the targetNetwork.
+It passes targetNetwork and msg as arguments to handleMessage on xCall.
 
-In summary, this code snippet illustrates a specific behavior expected from a connection regarding message sending and error handling.
-```javascript
+In case the message fails to be delivered for any reason, the connection triggers the `handleError` function.
+It passes the failed sn to the function.
+The responsibility of this function is to handle errors that occur during the message delivery process.
+
+The second external function, `getFee(network, response)`, calculates and returns the fee required to send a message to
+the specified network and back.
+It takes into account the optional response parameter when determining the fee.
+
+In summary, this code snippet illustrates a specific behavior expected from a connection regarding message sending and
+error handling.
+
+```
 external function sendMessage(targetNetwork, svc, sn, msg)
     On targetNetwork, trigger handleMessage(targetNetwork, msg)
     if message fails to deliver:
         trigger handleError(sn)
 ```
-``` javascript
+
+```
 external function getFee(network, response)
     Returns the fee required to send a message to "network" and back, considering the optional response parameter.
 ```
 
-
 ### Data Structures
+
 #### Messages
+
 All messages when passed to a connection are RLP encoded.
 RLP encoding order is the same as the order they are defined in below.
 
 ##### CSMessageRequest
-```javascript
+
+```
 CSMessageRequest {
     String from;
     String to;
@@ -255,8 +326,10 @@ CSMessageRequest {
     String[] protocols;
 }
 ```
+
 ##### CSMessageResponse
-```javascript
+
+```
 int SUCCESS = 1;
 int FAILURE = 0;
 CSMessageResponse {
@@ -264,8 +337,10 @@ CSMessageResponse {
     int code;
 }
 ```
+
 ##### CSMessage
-```javascript
+
+```
 int REQUEST = 1;
 int RESPONSE = 2;
 CSMessage {
@@ -277,7 +352,8 @@ CSMessage {
 ```
 
 #### Internal structs
-```javascript
+
+```
 CallRequest {
     Address from;
     String netTo;
@@ -286,7 +362,9 @@ CallRequest {
     boolean enabled = false; // defaults to false
 }
 ```
+
 ### Storage
+
 ```
 MAX_DATA_SIZE: <size>
 MAX_ROLLBACK_SIZE: <size>
@@ -309,27 +387,31 @@ feeHandler: <Address>
 ```
 
 ### Contract initialization
-```javascript
+
+```
 function init(String networkId) {
     NID = networkId
     if admin == null
         admin = getCaller();
-        feeHandler = getCaller();
+    feeHandler = getCaller();
 
 }
 ```
 
 ### Communication
+
 #### Sending messages
-`sendCallMessage` sends a some arbitrary data to `_to` via a path specified by the caller.
 
-`_to`: The network address of the target contract.
-`_data`: The data to be sent to the `_to` contract.
-`_rollback`: The data to be returned to the caller in case of failure.
-`sources`: A set of addresses representing the connections to be used when sending the message. These connections are also used to verify potential rollbacks
-`destination`: The addresses that the target contract should wait for messages from before considering it complete.
+`sendCallMessage` sends some arbitrary data to `_to` via a path specified by the caller.
 
-```javascript
+- `_to`: The network address of the target contract.
+- `_data`: The data to be sent to the `_to` contract.
+- `_rollback`: The data to be returned to the caller in case of failure.
+- `sources`: A set of addresses representing the connections to be used when sending the message.
+  These connections are also used to verify potential rollbacks
+- `destination`: The addresses that the target contract should wait for messages from before considering it complete.
+
+```
 payable external function sendCallMessage(String _to,
                                           byte[] _data,
                                           @Optional bytes _rollback,
@@ -373,12 +455,15 @@ payable external function sendCallMessage(String _to,
 }
 
 ```
+
 #### Receiving messages
+
 `handleMessage` is the external function used by connections to deliver messages.
-```javascript
+
+```
 external function handleMessage(String _from, bytes _msg) {
     msg = CSMessage.decode(_msg);
-    switch (msg.type):
+    switch (msg.type) :
         case CSMessage.REQUEST:
             handleRequest(_from, msg.data);
             break;
@@ -389,8 +474,10 @@ external function handleMessage(String _from, bytes _msg) {
             Context.revert("UnknownMsgType(" + msg.type + ")");
 }
 ```
-`handleError` is the external function used by connections to report error messages..
-```javascript
+
+`handleError` is the external function used by connections to report error messages.
+
+```
 external function handleError(BigInteger _sn) {
         CSMessageResponse res = CSMessageResponse(_sn, CSMessageResponse.FAILURE);
         handleResponse(res.toBytes());
@@ -399,21 +486,23 @@ external function handleError(BigInteger _sn) {
 
 `handleBTPMessage` Can be added to natively support the BTP protocol without a standalone connection.
 
-```javascript
+```
 external function handleBTPMessage(String _from, _svc String, Integer _sn, bytes _msg) {
     // verify svc is as registered
     handleMessage(_from, _msg)
 }
  ```
+
 `handleBTPError` Can be added to natively support the BTP protocol without a standalone connection.
-```javascript
+
+```
 external function handleBTPError(String _src, String _svc, BigInteger _sn, long _code, String _msg) {
     // verify svc is as registered
     handleError(_sn)
 }
 ```
 
-```javascript
+```
 internal function handleRequest(String srcNet, bytes data) {
     msgReq = CSMessageRequest.decode(data);
     from = NetworkAddress(msgReq.from);
@@ -441,7 +530,7 @@ internal function handleRequest(String srcNet, bytes data) {
 }
 ```
 
-```javascript
+```
 internal function handleResponse(data bytes) {
         response = CSMessageResponse.decode(data);
         resSn = response.sn;
@@ -481,8 +570,12 @@ internal function handleResponse(data bytes) {
 ```
 
 #### Message Execution
-If a two-message the function should allow the call to fail and send a new message to rollback the message. While if a one way message fails re-execution should be allowed.
-```javascript
+
+In case of a two-message call,
+the function should allow the call to fail and send a new message to roll back the message.
+While if a one way message fails, re-execution should be allowed.
+
+```
 external function executeCall(Integer _reqId, byte[] data) {
         req = proxyReqs[_reqId];
         require(req != null, "InvalidRequestId");
@@ -516,7 +609,8 @@ external function executeCall(Integer _reqId, byte[] data) {
     }
 
 ```
-```javascript
+
+```
 external function executeRollback(Integer _sn) {
     req = requests.get(_sn);
     require(req != null, "InvalidSerialNum");
@@ -528,14 +622,14 @@ external function executeRollback(Integer _sn) {
     else:
         req.from->handleCallMessage(getNetworkAddress(), req.rollback,  req.protocols);
 
-     RollbackExecuted(_sn);
+    emit RollbackExecuted(_sn);
 }
 
 ```
 
 ### Admin methods
 
-```javascript
+```
 adminOnly function setAdmin(Address admin){
     admin = admin
 }
@@ -555,25 +649,25 @@ adminOnly function setDefaultConnection(String nid, Address connection){
 
 ### Readonly methods
 
-```javascript
+```
 external readonly function  getNetworkAddress() returns String {
     return NetworkAddress(NID, this.address);
 }
 ```
 
-```javascript
+```
 external readonly function  getNetworkId() returns String {
     return NID;
 }
 ```
 
-```javascript
+```
 external readonly function  getProtocolFee() returns Integer {
     return protocolFee;
 }
 ```
 
-```javascript
+```
 external readonly function  getFee(String _net,
                                    boolean _rollback
                                    @Optional String[] sources)
@@ -590,44 +684,55 @@ external readonly function  getFee(String _net,
 }
 ```
 
-```javascript
+```
 external readonly function  verifySuccess(Integer sn) returns boolean {
     return successfulResponses[sn];
 }
 ```
 
 ## Differences from IIP52 xCall
-Multi protocol xCall is based on the inital spec defined in [IIP52](https://github.com/icon-project/IIPs/blob/master/IIPS/iip-52.md).
-* Two new optional parameters in sendCallMessage, `_sources` and `destinations`.
-    These parameters can be specified to choose the protocols to deliver the xCall message. If for example a dapp wanted to use BTP they would specify the address of BMC as the source and the address of BMC on destination chain as destinations.
+
+Multi protocol xCall is based on the initial spec defined
+in [IIP52](https://github.com/icon-project/IIPs/blob/master/IIPS/iip-52.md).
+
+* Two new optional parameters are added in sendCallMessage: `_sources` and `destinations`.
+  These parameters can be specified to choose the protocols to deliver the xCall message.
+  If, for example, a dapp wanted to use BTP, they specify the address of BMC as the source and the address of BMC on a
+  destination chain as destinations.
 
 * Rollback guarantees.
-    In IIP52 xCall rollback execution can only be tried once before removed which can cause loss of data in case of failure. In xCall multi protocol it can be retired until successful.
+  In IIP52, xCall rollback executions can only be tried once before removed, which can cause loss of data in case of
+  failure.
+  In xCall multi protocol, it can be retried until successful.
 
 * Two-way message success verification.
-    For all two way messages a response has to be relayed back since the fee has already been paid. This means the in most cases a response with the result success is being relayed back. In xCall multi protocol we store this success receipt so it can verified by dapps.
+  For all two-way messages, a response has to be relayed back since the fee has already been paid.
+  This means that in most cases, a response with the result success is being relayed back.
+  In xCall multi protocol, we store this success receipt so that it can be verified by dapps.
 
 * BTP address has been replaced completely by Network Address.
-    A BTP address is a Network Address as defined here with a "btp://" prefix. A Network Address in IIP52 refers to the Network Id in this document which might cause some confusion.
+  A BTP address is a Network Address as defined here with a `btp://` prefix.
+  A Network Address in IIP52 refers to the Network ID in this document which might cause some confusion.
 
-* The source of truth for a Network Id is now in xCall and not BMC.
+* The source of truth for a Network ID is now in xCall and not BMC.
 
-* `_nsn` is removed from CallMessageSent event.
+* `_nsn` is removed from `CallMessageSent` event.
 
 * Error messages are no longer relayed across chains in a response.
 
-* `_msg` has been removed from ResponseMessage event.
-    This is dues to the removal of relaying of error messages.
+* `_msg` has been removed from ResponseMessage event. This is due to the removal of relaying the error messages.
 
 * A message can now only be success or failure (1 or 0).
-    In IIP52 a message can have many different error codes but was not used by dapps and same behavior is not necessarily supported by all chains.
+  In IIP52 a message can have many different error codes but was not used by dapps and the same behavior is not
+  necessarily supported by all chains.
 
 * MaxDataSize is defined on the whole payload rather than only user data
-    This change was necessary to limit the size of the `_sources` and `destinations` parameters.
+  This change was necessary to limit the size of the `_sources` and `destinations` parameters.
 
 ### Error Handling
+
 ...
 
-
 ## FAQs
+
 ...


### PR DESCRIPTION
- wrap long lines
- Fix spelling errors
- reformat the documents

## Description:

### Commit Message

```bash
docs: proof read xcall document
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
0.1.0: reformat xcall document
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [X] I only have one commit (if not, squash them into one commit).
- [X] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
