### PR TITLE
fix: Improve parameter consistency in xCall java and spec

### DIFF
--- a/contracts/javascore/xcall/src/main/java/foundation/icon/xcall/CallService.java
+++ b/contracts/javascore/xcall/src/main/java/foundation/icon/xcall/CallService.java
@@ -48,8 +48,8 @@ public interface CallService {
     BigInteger sendCallMessage(String _to,
                                 byte[] _data,
                                 @Optional byte[] _rollback,
-                                @Optional String[] sources,
-                                @Optional String[] destinations);
+                                @Optional String[] _sources,
+                                @Optional String[] _destinations);
 
    /**
      * Handles incoming Messages.


### PR DESCRIPTION
## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
