### PR TITLE
ci: add manual cicd job to push release tag

### DIFF
--- a/.github/workflows/release-tag-manager.yml
+++ b/.github/workflows/release-tag-manager.yml
@@ -1,0 +1,32 @@
+name: Bump release tag version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release type (major / minor / patch)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.67.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: ${{ github.event.inputs.version }}
+


### PR DESCRIPTION
## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
